### PR TITLE
Add new symbol: !mavenArtifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Introduction.
 
-FitNesse plugin that provides Maven Classpath support.
+FitNesse plugin that provides Maven Classpath support 
+and let maven synchronize local repository with remote repo before tests starts.
+
+Maven must be installed and executable by FitNesse.
 
 # How to use.
 
@@ -8,13 +11,17 @@ FitNesse plugin that provides Maven Classpath support.
  - Get yourself an up-to-date copy of fitnesse (>= 20150114)
  - Add the following line to plugins.properties:
  
-       SymbolTypes = fitnesse.wikitext.widgets.MavenClasspathSymbolType
+       SymbolTypes = fitnesse.wikitext.widgets.MavenClasspathSymbolType,fitnesse.wikitext.widgets.MavenArtifactClasspathSymbolType
+
+ - Refer to the maven artifact as follows (dependencies will be downloaded by maven):
+ 
+       !mavenArtifact groupId:artifactId:version[:packaging[:classifier]][@scope]
 
  - Refer to the pom file as follows:
- 
+
        !pomFile /path/to/pom.xml
-        
- - you can define the file as `pom.xml@compile` to include a specific scope.
+
+ - you can define the file as `pom.xml@compile` to include a specific scope (default scope is 'test').
 
 # How to contribute.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
   </parent>
-  
+
   <groupId>org.fitnesse.plugins</groupId>
   <artifactId>maven-classpath-plugin</artifactId>
   <name>Maven Classpath Plugin</name>
   <version>1.10-SNAPSHOT</version>
   <url>https://github.com/amolenaar/fitnesse-maven-classpath</url>
-  
+
   <description>
     FitNesse plugin for adding libraries from a Maven pom.xml configuration.
   </description>
@@ -24,13 +25,13 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  
+
   <scm>
     <url>scm:git:git@github.com:amolenaar/fitnesse-maven-classpath.git</url>
     <connection>scm:git:git@github.com:amolenaar/fitnesse-maven-classpath.git</connection>
     <developerConnection>scm:git:git@github.com:amolenaar/fitnesse-maven-classpath.git</developerConnection>
   </scm>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.fitnesse</groupId>
@@ -51,19 +52,30 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>org.apache.maven</groupId>
-    	<artifactId>maven-embedder</artifactId>
-    	<version>3.0.4</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-invoker</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-embedder</artifactId>
+      <version>3.0.4</version>
+      <type>jar</type>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 
   <build>
+    <testResources>
+      <testResource>
+        <filtering>true</filtering>
+        <directory>src/test/resources</directory>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-4</version>
+        <version>3.0.0</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -81,6 +93,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -99,6 +112,11 @@
       <id>amolenaar</id>
       <email>amolenaar@xebia.com</email>
       <name>Arjan Molenaar</name>
+    </developer>
+    <developer>
+      <id>CyrilDeverson</id>
+      <email>cyril.deverson@free.fr</email>
+      <name>Cyril Deverson</name>
     </developer>
   </developers>
 </project>

--- a/src/main/java/fitnesse/wikitext/widgets/MavenArtifactClasspathExtractionException.java
+++ b/src/main/java/fitnesse/wikitext/widgets/MavenArtifactClasspathExtractionException.java
@@ -1,0 +1,13 @@
+package fitnesse.wikitext.widgets;
+
+@SuppressWarnings("serial")
+public class MavenArtifactClasspathExtractionException extends Exception {
+
+    public MavenArtifactClasspathExtractionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MavenArtifactClasspathExtractionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fitnesse/wikitext/widgets/MavenArtifactClasspathExtractor.java
+++ b/src/main/java/fitnesse/wikitext/widgets/MavenArtifactClasspathExtractor.java
@@ -1,0 +1,134 @@
+package fitnesse.wikitext.widgets;
+
+import org.apache.maven.shared.invoker.*;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLoggerManager;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class to extract classpath elements from Maven projects. Heavily based on code copied from Jenkin's Maven
+ * support.
+ */
+public class MavenArtifactClasspathExtractor {
+
+    public final static String DEFAULT_PACKAGING = "jar";
+	public final static String DEFAULT_SCOPE = "test";
+
+	private final Logger logger = new ConsoleLoggerManager().getLoggerForComponent("maven-classpath-plugin");
+
+    // Ensure M2_HOME variable is handled in a way similar to the mvn executable (script). To the extend possible.
+    static {
+        String m2Home = System.getenv().get("M2_HOME");
+        if (m2Home != null && System.getProperty("maven.home") == null) {
+            System.setProperty("maven.home", m2Home);
+        }
+    }
+
+    public List<String> extractClasspathEntries(MavenArtifactClasspathSymbolType.ParsedSymbol parsedSymbol) throws MavenArtifactClasspathExtractionException {
+        try {
+            File pomFile = createPomFile(parsedSymbol);
+
+            File dependencyList = invokeDependencyList(pomFile);
+
+            pomFile.delete();
+
+            List<String> classpath = parseClasspath(dependencyList);
+
+            dependencyList.delete();
+
+            return classpath;
+        } catch (IOException e) {
+            throw new MavenArtifactClasspathExtractionException("Could not extract classpath", e);
+        }
+    }
+
+    private List<String> parseClasspath(File dependencyList) throws MavenArtifactClasspathExtractionException {
+        Pattern pattern = Pattern.compile("(.*):([^:]+)");
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new FileReader(dependencyList));
+            while (!"The following files have been resolved:".equals(reader.readLine())) ;
+            List<String> classpath = new ArrayList<String>();
+            String line;
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                Matcher matcher = pattern.matcher(line);
+                if (matcher.find()) {
+                    // group 1 contains the path to the file
+                    classpath.add(matcher.group(2));
+                }
+            }
+            return classpath;
+        } catch (IOException e) {
+            throw new MavenArtifactClasspathExtractionException("Could not extract classpath", e);
+        } finally {
+            if(reader!=null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    throw new MavenArtifactClasspathExtractionException("Could not extract classpath", e);
+                }
+            }
+        }
+    }
+
+    private File invokeDependencyList(File pomFile) throws IOException, MavenArtifactClasspathExtractionException {
+        DefaultInvocationRequest request = new DefaultInvocationRequest();
+        request.setMavenOpts(System.getProperty("MAVEN_OPTS"));
+        request.setUserSettingsFile(new File(System.getProperty("MAVEN_SETTINGS_PATH")));
+        request.setBatchMode(true);
+        request.setUpdateSnapshots(true);
+        request.setGoals(Arrays.asList("-f " + pomFile.getPath(), "dependency:list"));
+
+        File dependencyList = File.createTempFile("fitnesse-maven-classpath-", ".deps");
+        Properties properties = new Properties();
+        properties.setProperty("outputFile", dependencyList.getPath()); // redirect output to a file
+        properties.setProperty("outputAbsoluteArtifactFilename", "true"); // with paths
+        request.setProperties(properties);
+
+        DefaultInvoker defaultInvoker = new DefaultInvoker();
+//        defaultInvoker.setOutputHandler(null); // not interested in Maven output itself
+        try {
+            InvocationResult result = defaultInvoker.execute(request);
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException("Build failed.");
+            }
+        } catch (MavenInvocationException e) {
+            throw new MavenArtifactClasspathExtractionException("Could not extract classpath", e);
+        }
+        return dependencyList;
+    }
+
+    private File createPomFile(MavenArtifactClasspathSymbolType.ParsedSymbol parsedSymbol) throws IOException {
+        File pomFile = File.createTempFile("fitnesse-maven-classpath-", ".pom");
+
+        PrintWriter writer = new PrintWriter(pomFile);
+        writer.println("<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
+        writer.println("         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">");
+        writer.println("    <modelVersion>4.0.0</modelVersion>");
+        writer.println("");
+        writer.println("    <groupId>org.fitnesse.plugins</groupId>");
+        writer.println("    <artifactId>maven-classpath-plugin</artifactId>");
+        writer.println("    <version>1.10-SNAPSHOT</version>");
+        writer.println("");
+        writer.println("    <dependencies>");
+        writer.println("        <dependency>");
+        writer.println("            <groupId>"+parsedSymbol.getGroupId()+"</groupId>");
+        writer.println("            <artifactId>"+parsedSymbol.getArtifactId()+"</artifactId>");
+        writer.println("            <version>"+parsedSymbol.getVersion()+"</version>");
+        writer.println("            <scope>"+parsedSymbol.getScope()+"</scope>");
+        writer.println("            <classifier>"+parsedSymbol.getClassifier()+"</classifier>");
+        writer.println("            <type>"+parsedSymbol.getPackaging()+"</type>");
+        writer.println("        </dependency>");
+        writer.println("    </dependencies>");
+        writer.println("</project>");
+        writer.close();
+        return pomFile;
+    }
+}

--- a/src/main/java/fitnesse/wikitext/widgets/MavenArtifactClasspathSymbolType.java
+++ b/src/main/java/fitnesse/wikitext/widgets/MavenArtifactClasspathSymbolType.java
@@ -1,0 +1,187 @@
+package fitnesse.wikitext.widgets;
+
+import fitnesse.wikitext.parser.*;
+import fitnesse.wikitext.parser.Matcher;
+import org.codehaus.plexus.PlexusContainerException;
+
+import java.util.*;
+import java.util.regex.*;
+
+/**
+ * FitNesse SymbolType implementation. Enables Maven classpath integration for FitNesse.
+ */
+public class MavenArtifactClasspathSymbolType extends SymbolType implements Rule, Translation, PathsProvider {
+    /**
+     * System property to disable this Symbol (if given value true).
+     */
+    public static final String DISABLE_KEY = "fitnesse.wikitext.widgets.MavenArtifactClasspathSymbolType.Disable";
+
+    private MavenArtifactClasspathExtractor mavenArtifactClasspathExtractor;
+
+    private final Map<String, List<String>> classpathCache = new HashMap<String, List<String>>();
+
+    public MavenArtifactClasspathSymbolType() throws PlexusContainerException {
+        super(MavenArtifactClasspathSymbolType.class.getSimpleName());
+
+        if (!Boolean.getBoolean(DISABLE_KEY)) {
+            this.mavenArtifactClasspathExtractor = new MavenArtifactClasspathExtractor();
+        }
+
+        wikiMatcher(new Matcher().startLineOrCell().string("!mavenArtifact"));
+
+        wikiRule(this);
+        htmlTranslation(this);
+    }
+
+    @Override
+    public String toTarget(Translator translator, Symbol symbol) {
+        ParsedSymbol parsedSymbol = getParsedSymbol(translator, symbol);
+        StringBuilder classpathForRender = new StringBuilder("<p class='meta'>Maven classpath [mavenArtifact: ")
+                .append(parsedSymbol.getSymbol())
+                .append(", scope: ")
+                .append(parsedSymbol.getScope())
+                .append("]:</p>")
+                .append("<ul class='meta'>");
+        try {
+            List<String> classpathElements = getClasspathElements(parsedSymbol);
+            for (String element : classpathElements) {
+                classpathForRender.append("<li>").append(element).append("</li>");
+            }
+        } catch (MavenArtifactClasspathExtractionException e) {
+            classpathForRender.append("<li class='error'>Unable to parse POM file: ")
+                    .append(e.getMessage()).append("</li>");
+        }
+
+        classpathForRender.append("</ul>");
+        return classpathForRender.toString();
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getClasspathElements(final ParsedSymbol parsedSymbol) throws MavenArtifactClasspathExtractionException {
+        String symbol = parsedSymbol.symbol;
+        if (classpathCache.containsKey(symbol)) {
+            return classpathCache.get(symbol);
+        } else {
+            List<String> classpath = Collections.emptyList();
+            if (mavenArtifactClasspathExtractor != null) {
+                classpath = mavenArtifactClasspathExtractor.extractClasspathEntries(parsedSymbol);
+            }
+            classpathCache.put(symbol, classpath);
+            return classpath;
+        }
+    }
+
+    private ParsedSymbol getParsedSymbol(Translator translator, Symbol symbol) {
+        return new ParsedSymbol(translator.translate(symbol.childAt(0)));
+    }
+
+    @Override
+    public Maybe<Symbol> parse(Symbol current, Parser parser) {
+        if (!parser.isMoveNext(SymbolType.Whitespace)) return Symbol.nothing;
+
+        return new Maybe<Symbol>(current.add(parser.parseToEnds(0, SymbolProvider.pathRuleProvider, new SymbolType[]{SymbolType.Newline})));
+    }
+
+    @Override
+    public boolean matchesFor(SymbolType symbolType) {
+        return symbolType instanceof Path || super.matchesFor(symbolType);
+    }
+
+    /**
+     * Exposed for testing
+     */
+    protected void setMavenArtifactClasspathExtractor(MavenArtifactClasspathExtractor mavenArtifactClasspathExtractor) {
+        this.mavenArtifactClasspathExtractor = mavenArtifactClasspathExtractor;
+    }
+
+    @Override
+    public Collection<String> providePaths(Translator translator, Symbol symbol) {
+        try {
+            return getClasspathElements(getParsedSymbol(translator, symbol));
+        } catch (MavenArtifactClasspathExtractionException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Turn the pom+scope key into a comparable object, using the pom's last modified timestamp as
+     * cache key.
+     */
+    static class ParsedSymbol {
+        private Pattern artifactCoordinatesPattern = Pattern.compile("([^:]+):([^:]+):([^:]+)(:([^:@]+)(:([^:@]+))?)?(@([^:]+))?");
+
+        private String symbol;
+
+        private String groupId;
+        private String artifactId;
+        private String version;
+        private String packaging;
+        private String classifier;
+
+        private String scope;
+
+        public ParsedSymbol(String symbol) {
+            super();
+            this.symbol = symbol;
+            parseSymbol();
+        }
+
+        private void parseSymbol() {
+            java.util.regex.Matcher matcher = artifactCoordinatesPattern.matcher(symbol);
+
+            if (matcher.matches()) {
+                groupId = matcher.group(1);
+                artifactId = matcher.group(2);
+                version = matcher.group(3);
+                packaging = matcher.group(5) == null ? MavenArtifactClasspathExtractor.DEFAULT_PACKAGING : matcher.group(5);
+                classifier = matcher.group(7) == null ? "" : matcher.group(7);
+                scope = matcher.group(9) == null ? MavenArtifactClasspathExtractor.DEFAULT_SCOPE : matcher.group(9);
+            }
+        }
+
+        public String getSymbol() {
+            return symbol;
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public String getArtifactId() {
+            return artifactId;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getClassifier() {
+            return classifier;
+        }
+
+        public String getPackaging() {
+            return packaging;
+        }
+
+        public String getScope() {
+            return scope;
+        }
+
+		/* hashCode() and equals() are optimized for used in the cache */
+
+        @Override
+        public int hashCode() {
+            return symbol.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof ParsedSymbol) {
+                ParsedSymbol ps = (ParsedSymbol) obj;
+                return symbol.equals(ps.symbol);
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/fitnesse/wikitext/widgets/MavenClasspathSymbolType.java
+++ b/src/main/java/fitnesse/wikitext/widgets/MavenClasspathSymbolType.java
@@ -47,7 +47,6 @@ public class MavenClasspathSymbolType extends SymbolType implements Rule, Transl
 
     @Override
     public String toTarget(Translator translator, Symbol symbol) {
-        List<String> classpathElements = null;
         ParsedSymbol parsedSymbol = getParsedSymbol(translator, symbol);
         StringBuilder classpathForRender = new StringBuilder("<p class='meta'>Maven classpath [file: ")
                 .append(parsedSymbol.getPomFile())
@@ -56,7 +55,7 @@ public class MavenClasspathSymbolType extends SymbolType implements Rule, Transl
                 .append("]:</p>")
                 .append("<ul class='meta'>");
         try {
-            classpathElements = getClasspathElements(parsedSymbol);
+            List<String> classpathElements = getClasspathElements(parsedSymbol);
             for (String element : classpathElements) {
                 classpathForRender.append("<li>").append(element).append("</li>");
             }
@@ -113,7 +112,7 @@ public class MavenClasspathSymbolType extends SymbolType implements Rule, Transl
         try {
             return getClasspathElements(getParsedSymbol(translator, symbol));
         } catch (MavenClasspathExtractionException e) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 	

--- a/src/test/java/fitnesse/wikitext/widgets/MavenArtifactClasspathExtractorTest.java
+++ b/src/test/java/fitnesse/wikitext/widgets/MavenArtifactClasspathExtractorTest.java
@@ -1,0 +1,26 @@
+package fitnesse.wikitext.widgets;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class MavenArtifactClasspathExtractorTest {
+    @Test
+    public void extractedClasspathIncludesTestScopeDependencies() throws Exception {
+        System.setProperty("MAVEN_SETTINGS_PATH","target/test-classes/user-settings.xml");
+        MavenArtifactClasspathExtractor extractor = new MavenArtifactClasspathExtractor();
+        List<String> classpath = extractor.extractClasspathEntries(new MavenArtifactClasspathSymbolType.ParsedSymbol("fitnesse:fitnesse-dep:1.0"));
+        Assert.assertFalse(classpath.isEmpty());
+
+        Iterator<String> classpathIter = classpath.iterator();
+        while (classpathIter.hasNext()) {
+            String classpathEntry = classpathIter.next();
+            if(classpathEntry.contains("fitnesse-dep-1.0.jar")) continue;
+            if(classpathEntry.contains("fitnesse-subdep-1.0.jar")) continue;
+            classpathIter.remove();
+        }
+        Assert.assertEquals(2, classpath.size());
+    }
+}

--- a/src/test/java/fitnesse/wikitext/widgets/MavenArtifactClasspathSymbolTypeTest.java
+++ b/src/test/java/fitnesse/wikitext/widgets/MavenArtifactClasspathSymbolTypeTest.java
@@ -1,0 +1,168 @@
+package fitnesse.wikitext.widgets;
+
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.fs.InMemoryPage;
+import fitnesse.wikitext.parser.Symbol;
+import fitnesse.wikitext.parser.SymbolProvider;
+import fitnesse.wikitext.parser.Translator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MavenArtifactClasspathSymbolTypeTest {
+
+    private MavenArtifactClasspathSymbolType mavenArtifactClasspathSymbolType;
+    private MavenArtifactClasspathExtractor mavenArtifactClasspathExtractor;
+    private Symbol symbol;
+    private WikiPage wikiPage;
+
+    @Before
+    public void setUp() throws Exception {
+        System.clearProperty(MavenArtifactClasspathSymbolType.DISABLE_KEY);
+        symbol = mock(Symbol.class);
+        wikiPage = InMemoryPage.makeRoot("RooT");
+        mavenArtifactClasspathExtractor = mock(MavenArtifactClasspathExtractor.class);
+
+        mavenArtifactClasspathSymbolType = new MavenArtifactClasspathSymbolType();
+        mavenArtifactClasspathSymbolType.setMavenArtifactClasspathExtractor(mavenArtifactClasspathExtractor);
+
+        System.setProperty("MAVEN_SETTINGS_PATH","target/test-classes/user-settings.xml");
+    }
+
+    @Test
+    public void testParsedSymbol() {
+        String symbol = "groupId:artifactId:version:packaging:classifier@runtime";
+        MavenArtifactClasspathSymbolType.ParsedSymbol parsedSymbol = new MavenArtifactClasspathSymbolType.ParsedSymbol(symbol);
+        assertEquals("groupId", parsedSymbol.getGroupId());
+        assertEquals("artifactId", parsedSymbol.getArtifactId());
+        assertEquals("version", parsedSymbol.getVersion());
+        assertEquals("packaging", parsedSymbol.getPackaging());
+        assertEquals("classifier", parsedSymbol.getClassifier());
+        assertEquals("runtime", parsedSymbol.getScope());
+    }
+
+    @Test
+    public void testParsedSymbol_withoutClassifier() {
+        String symbol = "groupId:artifactId:version:packaging@runtime";
+        MavenArtifactClasspathSymbolType.ParsedSymbol parsedSymbol = new MavenArtifactClasspathSymbolType.ParsedSymbol(symbol);
+        assertEquals("groupId", parsedSymbol.getGroupId());
+        assertEquals("artifactId", parsedSymbol.getArtifactId());
+        assertEquals("version", parsedSymbol.getVersion());
+        assertEquals("packaging", parsedSymbol.getPackaging());
+        assertEquals("", parsedSymbol.getClassifier());
+        assertEquals("runtime", parsedSymbol.getScope());
+    }
+
+    @Test
+    public void testParsedSymbol_withoutScope() {
+        String symbol = "groupId:artifactId:version:packaging";
+        MavenArtifactClasspathSymbolType.ParsedSymbol parsedSymbol = new MavenArtifactClasspathSymbolType.ParsedSymbol(symbol);
+        assertEquals("groupId", parsedSymbol.getGroupId());
+        assertEquals("artifactId", parsedSymbol.getArtifactId());
+        assertEquals("version", parsedSymbol.getVersion());
+        assertEquals("packaging", parsedSymbol.getPackaging());
+        assertEquals("", parsedSymbol.getClassifier());
+        assertEquals("test", parsedSymbol.getScope());
+    }
+
+    @Test
+    public void testParsedSymbol_withoutPackaging() {
+        String symbol = "groupId:artifactId:version";
+        MavenArtifactClasspathSymbolType.ParsedSymbol parsedSymbol = new MavenArtifactClasspathSymbolType.ParsedSymbol(symbol);
+        assertEquals("groupId", parsedSymbol.getGroupId());
+        assertEquals("artifactId", parsedSymbol.getArtifactId());
+        assertEquals("version", parsedSymbol.getVersion());
+        assertEquals("jar", parsedSymbol.getPackaging());
+        assertEquals("", parsedSymbol.getClassifier());
+        assertEquals("test", parsedSymbol.getScope());
+    }
+
+    @Test
+    public void testParsedSymbol_withoutVersion() {
+        String symbol = "groupId:artifactId";
+        MavenArtifactClasspathSymbolType.ParsedSymbol parsedSymbol = new MavenArtifactClasspathSymbolType.ParsedSymbol(symbol);
+        assertEquals(null, parsedSymbol.getGroupId());
+        assertEquals(null, parsedSymbol.getArtifactId());
+        assertEquals(null, parsedSymbol.getVersion());
+        assertEquals(null, parsedSymbol.getPackaging());
+        assertEquals(null, parsedSymbol.getClassifier());
+        assertEquals(null, parsedSymbol.getScope());
+    }
+
+    @Test
+    public void translatesToClasspathEntries() throws MavenArtifactClasspathExtractionException {
+        Symbol child = mock(Symbol.class);
+      Translator translator = mock(Translator.class);
+
+        when(symbol.childAt(0)).thenReturn(child);
+        when(translator.translate(child)).thenReturn("g:a:v");
+
+        when(mavenArtifactClasspathExtractor.extractClasspathEntries(any(MavenArtifactClasspathSymbolType.ParsedSymbol.class)))
+                .thenReturn(Arrays.asList("test1", "test2"));
+
+        assertEquals("<p class='meta'>Maven classpath [mavenArtifact: g:a:v, scope: test]:</p><ul class='meta'><li>test1</li><li>test2</li></ul>"
+                , mavenArtifactClasspathSymbolType.toTarget(translator, symbol));
+    }
+
+    @Test
+    public void translatesToJavaClasspath() throws MavenArtifactClasspathExtractionException {
+        Symbol child = mock(Symbol.class);
+        Translator translator = mock(Translator.class);
+
+        when(symbol.childAt(0)).thenReturn(child);
+        when(translator.translate(child)).thenReturn("g:a:v");
+
+        when(mavenArtifactClasspathExtractor.extractClasspathEntries(any(MavenArtifactClasspathSymbolType.ParsedSymbol.class)))
+                .thenReturn(Arrays.asList("test1", "test2"));
+
+        assertArrayEquals(new Object[]{"test1", "test2"}, mavenArtifactClasspathSymbolType.providePaths(translator, symbol).toArray());
+    }
+
+    @Test
+    public void loadPomXml() throws Exception {
+        configureMavenArtifactClasspathSymbolType();
+        PageData pageData = wikiPage.getData();
+        pageData.setContent("!mavenArtifact commons-lang:commons-lang:2.6:jar\n");
+        wikiPage.commit(pageData);
+        String html = wikiPage.getHtml();
+        assertTrue(html, html.startsWith("<p class='meta'>Maven classpath [mavenArtifact: commons-lang:commons-lang:2.6:jar, scope: test]:</p><ul class='meta'><li>"));
+    }
+
+    @Test
+    public void loadPomXmlFromVariable() throws Exception {
+        configureMavenArtifactClasspathSymbolType();
+        PageData pageData = wikiPage.getData();
+        pageData.setContent("!define MAVEN_ARTIFACT {commons-lang:commons-lang:2.6:jar}\n" +
+                "!mavenArtifact ${MAVEN_ARTIFACT}\n");
+        wikiPage.commit(pageData);
+        String html = wikiPage.getHtml();
+        assertTrue(html, html.contains("<p class='meta'>Maven classpath [mavenArtifact: commons-lang:commons-lang:2.6:jar, scope: test]:</p><ul class='meta'><li>"));
+    }
+
+    @Test
+    public void canBeDisabled() throws Exception {
+        System.setProperty(MavenArtifactClasspathSymbolType.DISABLE_KEY, "TRUE");
+        mavenArtifactClasspathSymbolType = new MavenArtifactClasspathSymbolType();
+
+        Symbol child = mock(Symbol.class);
+        Translator translator = mock(Translator.class);
+
+        when(symbol.childAt(0)).thenReturn(child);
+        when(translator.translate(child)).thenReturn("g:a:v");
+
+        assertEquals("<p class='meta'>Maven classpath [mavenArtifact: g:a:v, scope: test]:</p><ul class='meta'></ul>"
+                , mavenArtifactClasspathSymbolType.toTarget(translator, symbol));
+    }
+
+    private void configureMavenArtifactClasspathSymbolType() throws Exception {
+        SymbolProvider.wikiParsingProvider.add(new MavenArtifactClasspathSymbolType());
+    }
+}

--- a/src/test/resources/user-settings.xml
+++ b/src/test/resources/user-settings.xml
@@ -1,3 +1,17 @@
 <settings>
-  <localRepository>/tmp/fitnesse-maven-classpath/user-repository</localRepository>
+  <localRepository>${project.build.directory}/local-repository</localRepository>
+  <profiles>
+    <profile>
+      <id>test-repository</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>project-repository</id>
+          <url>file://${project.build.testOutputDirectory}/MavenClasspathWidget/repository</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 </settings>


### PR DESCRIPTION
This symbol enables user to define dependencies available from a remote maven repository.
To option is particularly interesting when no pom file is available locallly on the FitNesse server.

Additionally, this enhancement uses an external maven installation (not the embedded one) which make it easier to configure and update. 